### PR TITLE
Fix destination address for RabbitMQ

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -24,7 +24,7 @@
 		</layout>
 
 		<!-- RabbitMQ connection -->
-		<host>192.168.99.100</host>
+		<host>0.0.0.0</host>
 		<port>30000</port>
 		<username>guest</username>
 		<password>guest</password>


### PR DESCRIPTION
The address in the logback.xml file cannot be fixed since the listening socket of the test machine is unknown.